### PR TITLE
fix build tests on gcc 4.9+

### DIFF
--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -1,5 +1,9 @@
 include_directories(../include)
 
+if (NOT MSVC AND "${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-trampolines")
+endif ()
+
 set(TEST_SOURCES
   test/test.c
   test/test.h


### PR DESCRIPTION
Hi,

gcc 4.9.4 build ok, but clang 3.9.1 not support `-Wno-trampolines`, prohibits to create functions on stack and tests builds fail